### PR TITLE
新增船上实体清理选项，如果生物坐在船上则不会触发清理，通过配置文件配置

### DIFF
--- a/.idea/WorldListTrashCan.iml
+++ b/.idea/WorldListTrashCan.iml
@@ -1,8 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <module version="4">
-  <component name="AdditionalModuleElements">
-    <content url="file://$MODULE_DIR$" />
-  </component>
   <component name="FacetManager">
     <facet type="minecraft" name="Minecraft">
       <configuration>
@@ -11,6 +8,7 @@
           <platformType>ADVENTURE</platformType>
           <platformType>BUKKIT</platformType>
         </autoDetectTypes>
+        <projectReimportVersion>1</projectReimportVersion>
       </configuration>
     </facet>
   </component>

--- a/.idea/jarRepositories.xml
+++ b/.idea/jarRepositories.xml
@@ -17,6 +17,11 @@
       <option name="url" value="https://oss.sonatype.org/content/groups/public/" />
     </remote-repository>
     <remote-repository>
+      <option name="id" value="codemc-repo" />
+      <option name="name" value="codemc-repo" />
+      <option name="url" value="https://repo.codemc.io/repository/maven-public/" />
+    </remote-repository>
+    <remote-repository>
       <option name="id" value="papermc-repo" />
       <option name="name" value="papermc-repo" />
       <option name="url" value="https://repo.papermc.io/repository/maven-public/" />

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="EntryPointsManager">
     <list size="1">
@@ -12,7 +13,7 @@
       </list>
     </option>
   </component>
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_X" default="true" project-jdk-name="21" project-jdk-type="JavaSDK">
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_21" default="true" project-jdk-name="21" project-jdk-type="JavaSDK">
     <output url="file://$PROJECT_DIR$/out" />
   </component>
 </project>

--- a/WorldListTrashCan/src/main/java/org/worldlisttrashcan/TrashMain/ClearItemsTask.java
+++ b/WorldListTrashCan/src/main/java/org/worldlisttrashcan/TrashMain/ClearItemsTask.java
@@ -159,6 +159,7 @@ public class ClearItemsTask {
         boolean ClearAnimals = main.getConfig().getBoolean("Set.ClearEntity.ClearAnimals");
         boolean ClearProjectile = main.getConfig().getBoolean("Set.ClearEntity.ClearProjectile");
         boolean ClearReNameEntity = main.getConfig().getBoolean("Set.ClearEntity.ClearReNameEntity");
+        boolean IgnoreEntitiesInBoat = main.getConfig().getBoolean("Set.ClearEntity.IgnoreEntitiesInBoat");
 
         List<String> WhiteNameList = main.getConfig().getStringList("Set.ClearEntity.WhiteNameList");
         List<String> BlackNameList = main.getConfig().getStringList("Set.ClearEntity.BlackNameList");
@@ -565,6 +566,15 @@ public class ClearItemsTask {
 //                                    }
 
 //                                    System.out.println("实体: "+entity.getType().toString());
+
+                                        //检查实体是否在船上
+                                        if (IgnoreEntitiesInBoat && entity.isInsideVehicle()) {
+                                            Entity vehicle = entity.getVehicle();
+                                            if (vehicle instanceof Boat) {
+                                                //如果实体在船上，跳过清理
+                                                continue;
+                                            }
+                                        }
 
                                         if (BlackNameList.contains(entity.getType().toString().toLowerCase()) ||
                                                 BlackNameList.contains(entity.getName().toLowerCase())

--- a/WorldListTrashCan/src/main/java/org/worldlisttrashcan/TrashMain/FoliaClearItemsTask.java
+++ b/WorldListTrashCan/src/main/java/org/worldlisttrashcan/TrashMain/FoliaClearItemsTask.java
@@ -148,6 +148,7 @@ public class FoliaClearItemsTask {
         boolean ClearAnimals = main.getConfig().getBoolean("Set.ClearEntity.ClearAnimals");
         boolean ClearProjectile = main.getConfig().getBoolean("Set.ClearEntity.ClearProjectile");
         boolean ClearReNameEntity = main.getConfig().getBoolean("Set.ClearEntity.ClearReNameEntity");
+        boolean IgnoreEntitiesInBoat = main.getConfig().getBoolean("Set.ClearEntity.IgnoreEntitiesInBoat");
 
         List<String> WhiteNameList = main.getConfig().getStringList("Set.ClearEntity.WhiteNameList");
         List<String> BlackNameList = main.getConfig().getStringList("Set.ClearEntity.BlackNameList");
@@ -514,6 +515,15 @@ public class FoliaClearItemsTask {
 //                                blockState.update();
                                             } else {
                                                 if (ClearEntityFlag) {
+
+                                                    //检查实体是否在船上
+                                                    if (IgnoreEntitiesInBoat && entity.isInsideVehicle()) {
+                                                        Entity vehicle = entity.getVehicle();
+                                                        if (vehicle instanceof Boat) {
+                                                            //如果实体在船上，跳过清理
+                                                            continue;
+                                                        }
+                                                    }
 
                                                     if (BlackNameList.contains(entity.getType().toString().toLowerCase()) ||
                                                             BlackNameList.contains(entity.getName().toLowerCase())

--- a/WorldListTrashCan/src/main/java/org/worldlisttrashcan/WorldLimitEntityCount/removeEntity.java
+++ b/WorldListTrashCan/src/main/java/org/worldlisttrashcan/WorldLimitEntityCount/removeEntity.java
@@ -1,6 +1,7 @@
 package org.worldlisttrashcan.WorldLimitEntityCount;
 
 import org.bukkit.NamespacedKey;
+import org.bukkit.entity.Boat;
 import org.bukkit.entity.Entity;
 import org.bukkit.entity.EntityType;
 import org.bukkit.entity.LivingEntity;
@@ -39,6 +40,16 @@ public class removeEntity {
 //        EntityType entityType = entity.getType();
         String entityType = entity.getName();
         entityType = entityType.toUpperCase();
+
+        //检查实体是否在船上，如果配置开启且实体在船上，则跳过处理
+        boolean ignoreEntitiesInBoat = main.getConfig().getBoolean("Set.ClearEntity.IgnoreEntitiesInBoat");
+        if (ignoreEntitiesInBoat && entity.isInsideVehicle()) {
+            Entity vehicle = entity.getVehicle();
+            if (vehicle instanceof Boat) {
+                //如果实体在船上，跳过处理
+                return;
+            }
+        }
 
 
 //        int limit = GatherLimits.get(entityType.name())[0];

--- a/WorldListTrashCan/src/main/resources/config.yml
+++ b/WorldListTrashCan/src/main/resources/config.yml
@@ -157,6 +157,8 @@ Set:
     ClearProjectile: true
     #是否清理被命名过的生物
     ClearReNameEntity: false
+    #是否忽略在船上的生物（如果为true，则不会清理坐在船上的生物）
+    IgnoreEntitiesInBoat: true
     #如果在以下名单内，不会清理（白名单）
     WhiteNameList:
       - VILLAGER


### PR DESCRIPTION
在 Paper1.21.8 测试可用，其他版本没测试环境，打包后插件放在[Release](https://github.com/ZH0531/WorldListTrashCan/releases/tag/Release)了

- 在配置文件中添加 IgnoreEntitiesInBoat 开关
- 在 ClearItemsTask.java 中添加船上实体检测逻辑
- 在 FoliaClearItemsTask.java 中添加船上实体检测逻辑
- 在 removeEntity.java 中添加船上实体检测逻辑

